### PR TITLE
Expose ovs-vsctl-timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -262,6 +262,11 @@ options:
     description: |
       Default multicast port number that will be used to communicate between
       HA Cluster nodes.
+  ovs-vsctl-timeout:
+    type: int
+    default: 10
+    description: |
+      Timeout in seconds for ovs-vsctl commands.
   # Monitoring config
   nagios_context:
     type: string

--- a/hooks/neutron_contexts.py
+++ b/hooks/neutron_contexts.py
@@ -98,6 +98,7 @@ class NeutronGatewayContext(NeutronAPIContext):
             'report_interval': api_settings['report_interval'],
             'enable_metadata_network': config('enable-metadata-network'),
             'enable_isolated_metadata': config('enable-isolated-metadata'),
+            'ovs_vsctl_timeout': config('ovs-vsctl-timeout'),
         }
 
         fallback = get_host_ip(unit_get('private-address'))

--- a/templates/mitaka/openvswitch_agent.ini
+++ b/templates/mitaka/openvswitch_agent.ini
@@ -3,6 +3,11 @@
 # [ WARNING ]
 # Configuration file maintained by Juju. Local changes may be overwritten.
 ###############################################################################
+[DEFAULT]
+{% if ovs_vsctl_timeout -%}
+ovs_vsctl_timeout = {{ ovs_vsctl_timeout }}
+{% endif -%}
+
 [ovs]
 enable_tunneling = True
 local_ip = {{ local_ip }}

--- a/templates/newton/l3_agent.ini
+++ b/templates/newton/l3_agent.ini
@@ -20,6 +20,9 @@ use_namespaces = True
 {% else %}
 ovs_use_veth = True
 {% endif %}
+{% if ovs_vsctl_timeout -%}
+ovs_vsctl_timeout = {{ ovs_vsctl_timeout }}
+{% endif -%}
 {% if external_configuration_new -%}
 gateway_external_network_id =
 external_network_bridge =

--- a/tests/basic_deployment.py
+++ b/tests/basic_deployment.py
@@ -997,6 +997,54 @@ class NeutronGatewayBasicDeployment(OpenStackAmuletDeployment):
             self.d.configure('neutron-api', set_default)
             u.log.debug('OK')
 
+    def test_410_ovs_timeout_ovs(self):
+        """Check ovs_timeout settings in ovs_agent.ini"""
+        if self._get_openstack_release() >= self.trusty_mitaka:
+            unit = self.neutron_gateway_sentry
+            expected = '123'
+            set_default = {'ovs-vsctl-timeout': '60'}
+            set_alternate = {'ovs-vsctl-timeout': expected}
+            self.d.configure('neutron-gateway', set_alternate)
+            time.sleep(60)
+            self._auto_wait_for_status(exclude_services=self.exclude_services)
+            config = u._get_config(
+                unit,
+                '/etc/neutron/plugins/ml2/openvswitch_agent.ini')
+            timeout = config.get('DEFAULT', 'ovs_vsctl_timeout')
+
+            if timeout != expected:
+                msg = "ovs-vsctl-timeout not expected value in openvswitch_agent.ini: "
+                      "{} != {}".format(timeout, expected)
+                amulet.raise_status(amulet.FAIL, msg=msg)
+            u.log.debug('Setting ovs-vsctl-timeout back to {}'.format(
+                set_default['ovs-vsctl-timeout']))
+            self.d.configure('neutron-gateway', set_default)
+            u.log.debug('OK')
+
+    def test_411_ovs_timeout_l3(self):
+        """Check ovs_timeout settings in ovs_agent.ini"""
+        if self._get_openstack_release() >= self.trusty_newton:
+            unit = self.neutron_gateway_sentry
+            expected = '123'
+            set_default = {'ovs-vsctl-timeout': '60'}
+            set_alternate = {'ovs-vsctl-timeout': expected}
+            self.d.configure('neutron-gateway', set_alternate)
+            time.sleep(60)
+            self._auto_wait_for_status(exclude_services=self.exclude_services)
+            config_l3 = u._get_config(
+                unit,
+                '/etc/neutron/l3_agent.ini')
+            timeout_l3 = config.get('DEFAULT', 'ovs_vsctl_timeout')
+
+            if timeout_l3 != expected:
+                msg = "ovs-vsctl-timeout not expected value in "
+                      "l3_agent.ini: {} != {}".format(timeout, expected)
+                amulet.raise_status(amulet.FAIL, msg=msg)
+            u.log.debug('Setting ovs-vsctl-timeout back to {}'.format(
+                set_default['ovs-vsctl-timeout']))
+            self.d.configure('neutron-gateway', set_default)
+            u.log.debug('OK')
+
     def test_900_restart_on_config_change(self):
         """Verify that the specified services are restarted when the
         config is changed."""

--- a/unit_tests/test_neutron_contexts.py
+++ b/unit_tests/test_neutron_contexts.py
@@ -158,6 +158,7 @@ class TestNeutronGatewayContext(CharmTestCase):
                  'enable-qos': 'True',
                  'network-device-mtu': 9000,
                  'dns-domain': 'openstack.example.'}
+        self.test_config.set('ovs-vsctl-timeout', 23)
         self.test_config.set('plugin', 'ovs')
         self.test_config.set('debug', False)
         self.test_config.set('verbose', True)
@@ -177,6 +178,7 @@ class TestNeutronGatewayContext(CharmTestCase):
         _secret.return_value = 'testsecret'
         ctxt = neutron_contexts.NeutronGatewayContext()()
         self.assertEqual(ctxt, {
+            'ovs_vsctl_timeout': 23,
             'shared_secret': 'testsecret',
             'enable_dvr': True,
             'enable_l3ha': True,
@@ -236,6 +238,7 @@ class TestNeutronGatewayContext(CharmTestCase):
         _secret.return_value = 'testsecret'
         ctxt = neutron_contexts.NeutronGatewayContext()()
         self.assertEqual(ctxt, {
+            'ovs_vsctl_timeout': 10,
             'shared_secret': 'testsecret',
             'enable_dvr': True,
             'enable_l3ha': True,


### PR DESCRIPTION
Expose a new config option ovs-vsctl-timeout which specifies the
timeout in seconds for ovs-vsctl commands in both openvswitch_agent.ini
and the l3_agent.ini files to avoid restarting more services than
necessary for this common config option.

Closes-Bug: #1738123
Change-Id: I50f29fe932e39b1d35a3ccbfd82aee167d019b27