### PR TITLE
Expose ovs-vsctl-timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -262,6 +262,11 @@ options:
     description: |
       Default multicast port number that will be used to communicate between
       HA Cluster nodes.
+  ovs-vsctl-timeout:
+    type: int
+    default: 10
+    description: |
+      Timeout in seconds for ovs-vsctl commands.
   # Monitoring config
   nagios_context:
     type: string

--- a/hooks/neutron_contexts.py
+++ b/hooks/neutron_contexts.py
@@ -101,6 +101,7 @@ class NeutronGatewayContext(NeutronAPIContext):
             'report_interval': api_settings['report_interval'],
             'enable_metadata_network': config('enable-metadata-network'),
             'enable_isolated_metadata': config('enable-isolated-metadata'),
+            'ovs_vsctl_timeout': config('ovs-vsctl-timeout'),
         }
 
         fallback = get_host_ip(unit_get('private-address'))

--- a/templates/mitaka/openvswitch_agent.ini
+++ b/templates/mitaka/openvswitch_agent.ini
@@ -3,6 +3,11 @@
 # [ WARNING ]
 # Configuration file maintained by Juju. Local changes may be overwritten.
 ###############################################################################
+[DEFAULT]
+{% if ovs_vsctl_timeout -%}
+ovs_vsctl_timeout = {{ ovs_vsctl_timeout }}
+{% endif -%}
+
 [ovs]
 enable_tunneling = True
 local_ip = {{ local_ip }}

--- a/templates/newton/l3_agent.ini
+++ b/templates/newton/l3_agent.ini
@@ -20,6 +20,9 @@ use_namespaces = True
 {% else %}
 ovs_use_veth = True
 {% endif %}
+{% if ovs_vsctl_timeout -%}
+ovs_vsctl_timeout = {{ ovs_vsctl_timeout }}
+{% endif -%}
 {% if external_configuration_new -%}
 gateway_external_network_id =
 external_network_bridge =

--- a/unit_tests/test_neutron_contexts.py
+++ b/unit_tests/test_neutron_contexts.py
@@ -156,6 +156,7 @@ class TestNeutronGatewayContext(CharmTestCase):
                  'enable-l3ha': 'True',
                  'network-device-mtu': 9000,
                  'dns-domain': 'openstack.example.'}
+        self.test_config.set('ovs-vsctl-timeout', 23)
         self.test_config.set('plugin', 'ovs')
         self.test_config.set('debug', False)
         self.test_config.set('verbose', True)
@@ -174,7 +175,8 @@ class TestNeutronGatewayContext(CharmTestCase):
         _rget.side_effect = lambda *args, **kwargs: rdata
         _secret.return_value = 'testsecret'
         ctxt = neutron_contexts.NeutronGatewayContext()()
-        self.assertEquals(ctxt, {
+        self.assertEqual(ctxt, {
+            'ovs_vsctl_timeout': 23,
             'shared_secret': 'testsecret',
             'enable_dvr': True,
             'enable_l3ha': True,
@@ -231,7 +233,8 @@ class TestNeutronGatewayContext(CharmTestCase):
         _rget.side_effect = lambda *args, **kwargs: rdata
         _secret.return_value = 'testsecret'
         ctxt = neutron_contexts.NeutronGatewayContext()()
-        self.assertEquals(ctxt, {
+        self.assertEqual(ctxt, {
+            'ovs_vsctl_timeout': 10,
             'shared_secret': 'testsecret',
             'enable_dvr': True,
             'enable_l3ha': True,


### PR DESCRIPTION
Expose a new config option ovs-vsctl-timeout which specifies the
timeout in seconds for ovs-vsctl commands in both openvswitch_agent.ini
and the l3_agent.ini files to avoid restarting more services than
necessary for this common config option.

Closes-Bug: #1738123
Change-Id: I50f29fe932e39b1d35a3ccbfd82aee167d019b27